### PR TITLE
Tolerate missing permission set classes

### DIFF
--- a/app/models/spree/role_decorator.rb
+++ b/app/models/spree/role_decorator.rb
@@ -1,22 +1,34 @@
-Spree::Role.class_eval do
-  has_many :role_permissions, dependent: :destroy
-  has_many :permission_sets, through: :role_permissions
+module Spree
+  module RoleDecorator
+    def self.prepended(base)
+      base.has_many :role_permissions, dependent: :destroy
+      base.has_many :permission_sets, through: :role_permissions
 
-  scope :non_base_roles, -> { where.not(name: ['admin', 'user']) }
-  validates :name, uniqueness: true
-  after_save :assign_permissions
-
-  def permission_sets_constantized
-    permission_sets.map(&:set).map(&:constantize)
-  end
-
-  def assign_permissions
-    if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
-      Spree::RoleConfiguration.configure do |config|
-        config.assign_permissions name, permission_sets_constantized
-      end
-    else
-      Spree::Config.roles.assign_permissions name, permission_sets_constantized
+      base.scope :non_base_roles, -> { where.not(name: ['admin', 'user']) }
+      base.validates :name, uniqueness: true
+      base.after_save :assign_permissions
     end
+
+    def permission_sets_constantized
+      permission_sets.map(&:set).map { |set_class_name|
+        begin
+          set_class_name.constantize
+        rescue NameError
+          nil
+        end
+      }.compact
+    end
+
+    def assign_permissions
+      if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')
+        Spree::RoleConfiguration.configure do |config|
+          config.assign_permissions name, permission_sets_constantized
+        end
+      else
+        Spree::Config.roles.assign_permissions name, permission_sets_constantized
+      end
+    end
+
+    Spree::Role.prepend(self)
   end
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :permission_set, class: Spree::PermissionSet do
-    name 'ProductManagement'
-    set 'Spree::PermissionSets::ProductManagement'
+    name { 'ProductManagement' }
+    set { 'Spree::PermissionSets::ProductManagement' }
   end
 end

--- a/spec/models/spree/role_spec.rb
+++ b/spec/models/spree/role_spec.rb
@@ -10,6 +10,25 @@ describe Spree::Role, type: :model do
     role
   }
 
+  describe '#permission_sets_constantized' do
+    context 'when a permission set no longer exists' do
+      let(:role) { create(:role) }
+      let(:permission_set) { create(:permission_set) }
+      let(:ghost_permission_set) {
+        create(:permission_set, name: 'WidgetDisplay', set: 'Spree::PermissionSets::WidgetDisplay')
+      }
+
+      before do
+        role.permission_sets << permission_set
+        role.permission_sets << ghost_permission_set
+      end
+
+      it 'returns the remaining permission set classes' do
+        expect(role.permission_sets_constantized.count).to eq(1)
+      end
+    end
+  end
+
   context "#assign_permissions" do
     it 'creates new Spree::RoleConfiguration::Role' do
       if SolidusSupport.solidus_gem_version < Gem::Version.new('2.5.x')


### PR DESCRIPTION
In some cases, a permission set class that is referred to in a role
definition may be removed. We need to tolerate that absence so that the
application can start normally.